### PR TITLE
implement OTP verification screen with error handling

### DIFF
--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_login_two_themes/presentation/screens/auth/auth_screen.dart';
+import 'package:flutter_login_two_themes/presentation/screens/home/home_screen.dart';
 
 class AppRouter {
   Route? generateRoute(RouteSettings settings) {
@@ -7,6 +8,10 @@ class AppRouter {
       case '/':
         return MaterialPageRoute(
           builder: (_) => const AuthScreen(),
+        );
+      case '/home':
+        return MaterialPageRoute(
+          builder: (_) => const HomeScreen(),
         );
       default:
         return MaterialPageRoute(

--- a/lib/constants/themes/app_text_styles.dart
+++ b/lib/constants/themes/app_text_styles.dart
@@ -1,0 +1,191 @@
+import 'package:flutter/material.dart';
+import 'app_colors.dart';
+
+class AppTextStyles {
+  // Title Styles
+  static TextStyle get titleLarge => const TextStyle(
+        fontSize: 32,
+        fontWeight: FontWeight.w800,
+        letterSpacing: -0.5,
+      );
+
+  static TextStyle get titleMedium => const TextStyle(
+        fontSize: 20,
+        fontWeight: FontWeight.w700,
+        letterSpacing: -0.5,
+      );
+
+  static TextStyle get titleSmall => const TextStyle(
+        fontSize: 18,
+        fontWeight: FontWeight.w600,
+        letterSpacing: -0.3,
+      );
+
+  // Body Styles
+  static TextStyle get bodyLarge => const TextStyle(
+        fontSize: 16,
+        fontWeight: FontWeight.w400,
+        height: 1.5,
+      );
+
+  static TextStyle get bodyMedium => const TextStyle(
+        fontSize: 14,
+        fontWeight: FontWeight.w400,
+        height: 1.4,
+      );
+
+  static TextStyle get bodySmall => const TextStyle(
+        fontSize: 12,
+        fontWeight: FontWeight.w400,
+        height: 1.3,
+      );
+
+  // Label Styles
+  static TextStyle get labelLarge => const TextStyle(
+        fontSize: 14,
+        fontWeight: FontWeight.w600,
+        letterSpacing: 0.1,
+      );
+
+  static TextStyle get labelMedium => const TextStyle(
+        fontSize: 12,
+        fontWeight: FontWeight.w500,
+        letterSpacing: 0.1,
+      );
+
+  static TextStyle get labelSmall => const TextStyle(
+        fontSize: 10,
+        fontWeight: FontWeight.w500,
+        letterSpacing: 0.1,
+      );
+
+  // Button Styles
+  static TextStyle get buttonLarge => const TextStyle(
+        fontSize: 16,
+        fontWeight: FontWeight.w600,
+        letterSpacing: 0.1,
+      );
+
+  static TextStyle get buttonMedium => const TextStyle(
+        fontSize: 14,
+        fontWeight: FontWeight.w600,
+        letterSpacing: 0.1,
+      );
+
+  static TextStyle get buttonSmall => const TextStyle(
+        fontSize: 12,
+        fontWeight: FontWeight.w600,
+        letterSpacing: 0.1,
+      );
+
+  // Input Styles
+  static TextStyle get inputText => const TextStyle(
+        fontSize: 16,
+        fontWeight: FontWeight.w400,
+        letterSpacing: 0.1,
+      );
+
+  static TextStyle get inputLabel => const TextStyle(
+        fontSize: 14,
+        fontWeight: FontWeight.w500,
+        letterSpacing: 0.1,
+      );
+
+  static TextStyle get inputHint => const TextStyle(
+        fontSize: 16,
+        fontWeight: FontWeight.w400,
+        letterSpacing: 0.1,
+      );
+
+  // OTP Field Styles
+  static TextStyle get otpField => const TextStyle(
+        fontSize: 20,
+        fontWeight: FontWeight.w600,
+        letterSpacing: 0.5,
+      );
+
+  // Link Styles
+  static TextStyle get link => const TextStyle(
+        fontSize: 14,
+        fontWeight: FontWeight.w600,
+        decoration: TextDecoration.underline,
+        letterSpacing: 0.1,
+      );
+
+  // Caption Styles
+  static TextStyle get caption => const TextStyle(
+        fontSize: 12,
+        fontWeight: FontWeight.w400,
+        height: 1.3,
+      );
+
+  // Helper method to get themed text style
+  static TextStyle themed(
+    BuildContext context, {
+    required TextStyle baseStyle,
+    Color? lightColor,
+    Color? darkColor,
+  }) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return baseStyle.copyWith(
+      color: isDark ? darkColor : lightColor,
+    );
+  }
+
+  // Predefined themed styles for common use cases
+  static TextStyle titleLargeThemed(BuildContext context) => themed(
+        context,
+        baseStyle: titleLarge,
+        lightColor: AppColors.gray900,
+        darkColor: Colors.white,
+      );
+
+  static TextStyle titleMediumThemed(BuildContext context) => themed(
+        context,
+        baseStyle: titleMedium,
+        lightColor: AppColors.gray900,
+        darkColor: Colors.white,
+      );
+
+  static TextStyle bodyLargeThemed(BuildContext context) => themed(
+        context,
+        baseStyle: bodyLarge,
+        lightColor: AppColors.gray600,
+        darkColor: Colors.white.withValues(alpha: 0.8),
+      );
+
+  static TextStyle bodyMediumThemed(BuildContext context) => themed(
+        context,
+        baseStyle: bodyMedium,
+        lightColor: AppColors.gray600,
+        darkColor: Colors.white.withValues(alpha: 0.8),
+      );
+
+  static TextStyle buttonPrimaryThemed(BuildContext context) => themed(
+        context,
+        baseStyle: buttonLarge,
+        lightColor: Colors.white,
+        darkColor: Colors.white,
+      );
+
+  static TextStyle buttonSecondaryThemed(BuildContext context) => themed(
+        context,
+        baseStyle: buttonMedium,
+        lightColor: AppColors.primary,
+        darkColor: AppColors.primary,
+      );
+
+  static TextStyle linkThemed(BuildContext context) => themed(
+        context,
+        baseStyle: link,
+        lightColor: AppColors.primary,
+        darkColor: AppColors.primary,
+      );
+
+  static TextStyle captionThemed(BuildContext context) => themed(
+        context,
+        baseStyle: caption,
+        lightColor: AppColors.gray500,
+        darkColor: AppColors.gray400,
+      );
+} 

--- a/lib/constants/widgets/app_button.dart
+++ b/lib/constants/widgets/app_button.dart
@@ -1,0 +1,158 @@
+import 'package:flutter/material.dart';
+
+class AppButton extends StatelessWidget {
+  final String text;
+  final VoidCallback? onPressed;
+  final bool isPrimary;
+  final bool isFullWidth;
+  final IconData? icon;
+  final double? height;
+  final double borderRadius;
+  final TextStyle? textStyle;
+
+  const AppButton({
+    super.key,
+    required this.text,
+    this.onPressed,
+    this.isPrimary = true,
+    this.isFullWidth = true,
+    this.icon,
+    this.height = 52,
+    this.borderRadius = 12,
+    this.textStyle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    final colorScheme = theme.colorScheme;
+    final isDark = theme.brightness == Brightness.dark;
+
+    final buttonStyle = isPrimary
+        ? ElevatedButton.styleFrom(
+            backgroundColor: colorScheme.primary,
+            foregroundColor: colorScheme.onPrimary,
+            minimumSize: Size.fromHeight(height!),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(borderRadius),
+            ),
+            elevation: 0,
+          )
+        : OutlinedButton.styleFrom(
+            backgroundColor: theme.cardColor,
+            foregroundColor: colorScheme.onSurface,
+            side: BorderSide(
+              color: isDark ? Colors.white24 : colorScheme.outline,
+              width: 1.5,
+            ),
+            minimumSize: Size.fromHeight(height!),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(borderRadius),
+            ),
+            elevation: 0,
+          );
+
+    final buttonTextColor = isPrimary
+        ? (isDark ? Colors.black : Colors.white)
+        : (isDark ? Colors.white : Colors.black);
+
+    final buttonTextStyle = (textStyle ?? textTheme.labelLarge)?.copyWith(
+      fontWeight: FontWeight.w600,
+      letterSpacing: 0.2,
+      color: buttonTextColor,
+    );
+
+    final button = isPrimary
+        ? ElevatedButton(
+            onPressed: onPressed,
+            style: buttonStyle,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (icon != null) ...[
+                  Icon(icon, size: 20),
+                  const SizedBox(width: 8),
+                ],
+                Text(text, style: buttonTextStyle),
+              ],
+            ),
+          )
+        : OutlinedButton(
+            onPressed: onPressed,
+            style: buttonStyle,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (icon != null) ...[
+                  Icon(icon, size: 20),
+                  const SizedBox(width: 8),
+                ],
+                Text(text, style: buttonTextStyle),
+              ],
+            ),
+          );
+
+    return isFullWidth
+        ? SizedBox(width: double.infinity, child: button)
+        : button;
+  }
+}
+
+class PrimaryButton extends StatelessWidget {
+  final String text;
+  final VoidCallback? onPressed;
+  final bool isFullWidth;
+  final IconData? icon;
+  final double? height;
+
+  const PrimaryButton({
+    super.key,
+    required this.text,
+    this.onPressed,
+    this.isFullWidth = true,
+    this.icon,
+    this.height = 52,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AppButton(
+      text: text,
+      onPressed: onPressed,
+      isPrimary: true,
+      isFullWidth: isFullWidth,
+      icon: icon,
+      height: height,
+    );
+  }
+}
+
+class SecondaryButton extends StatelessWidget {
+  final String text;
+  final VoidCallback? onPressed;
+  final bool isFullWidth;
+  final IconData? icon;
+  final double? height;
+
+  const SecondaryButton({
+    super.key,
+    required this.text,
+    this.onPressed,
+    this.isFullWidth = true,
+    this.icon,
+    this.height = 52,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AppButton(
+      text: text,
+      onPressed: onPressed,
+      isPrimary: false,
+      isFullWidth: isFullWidth,
+      icon: icon,
+      height: height,
+    );
+  }
+} 

--- a/lib/constants/widgets/background_wrapper.dart
+++ b/lib/constants/widgets/background_wrapper.dart
@@ -1,13 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_login_two_themes/presentation/widgets/auth/theme_toggle_button.dart';
 
 class AppBackground extends StatelessWidget {
   final Widget child;
-  const AppBackground({super.key, required this.child});
+  final bool showThemeToggle;
+  final bool showBackButton;
+
+  const AppBackground({
+    super.key,
+    required this.child,
+    this.showThemeToggle = true,
+    this.showBackButton = false,
+  });
 
   @override
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
-
     return Container(
       width: double.infinity,
       height: double.infinity,
@@ -17,9 +25,9 @@ class AppBackground extends StatelessWidget {
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
                 colors: [
-                  Color(0xFF1E40AF),     // Top Left → Bright Blue
-                  Color(0xFF0B132B),     // Center Diagonal → Deep Dark Blue
-                  Color(0xFF1E40AF),     // Bottom Right → Bright Blue
+                  Color(0xFF1E40AF),
+                  Color(0xFF0B132B),
+                  Color(0xFF1E40AF),
                 ],
                 stops: [0.0, 0.5, 1.0],
               )
@@ -27,14 +35,50 @@ class AppBackground extends StatelessWidget {
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
                 colors: [
-                  Color(0xFFEFF3FC),     // Light blue/white
-                  Color(0xFFFFFFFF),     // Center soft white
+                  Color(0xFFEFF3FC),
+                  Color(0xFFFFFFFF),
                   Color(0xFFEFF3FC),
                 ],
                 stops: [0.0, 0.5, 1.0],
               ),
       ),
-      child: child,
+      child: Column(
+        children: [
+          const SizedBox(height: 16),
+          if (showThemeToggle || showBackButton)
+            Padding(
+              padding: const EdgeInsets.only(top: 16, left: 8, right: 8),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  if (showBackButton)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 12, left: 6),
+                      child: Align(
+                        alignment: Alignment.topLeft,
+                        child: IconButton(
+                          style: IconButton.styleFrom(
+                            backgroundColor: Theme.of(context).colorScheme.surface,
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                            padding: const EdgeInsets.all(12),
+                          ),
+                          icon: const Icon(Icons.arrow_back),
+                          color: isDark ? Colors.white : Colors.black,
+                          onPressed: () => Navigator.of(context).maybePop(),
+                        ),
+                      ),
+                    ),
+                  if (!showBackButton) const SizedBox(width: 48),
+                  if (showThemeToggle) const ThemeToggleButton(),
+                  if (!showThemeToggle) const SizedBox(width: 48),
+                ],
+              ),
+            ),
+          Expanded(child: child),
+        ],
+      ),
     );
   }
 }

--- a/lib/constants/widgets/feature_icon.dart
+++ b/lib/constants/widgets/feature_icon.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import '../themes/app_colors.dart';
+
+class FeatureIcon extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final Color iconColor;
+  final Color bgColor;
+  final double size;
+  final double iconSize;
+  final double borderRadius;
+  final TextStyle? labelStyle;
+
+  const FeatureIcon({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.iconColor,
+    required this.bgColor,
+    this.size = 56,
+    this.iconSize = 28,
+    this.borderRadius = 28,
+    this.labelStyle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final textTheme = theme.textTheme;
+
+    return Column(
+      children: [
+        Container(
+          width: size,
+          height: size,
+          decoration: BoxDecoration(
+            color: isDark ? iconColor.withValues(alpha: 0.2) : bgColor,
+            borderRadius: BorderRadius.circular(borderRadius),
+            boxShadow: [
+              BoxShadow(
+                color: isDark 
+                    ? Colors.black.withValues(alpha: 0.2) 
+                    : Colors.black.withValues(alpha: 0.08),
+                blurRadius: 8,
+                offset: const Offset(0, 3),
+              ),
+            ],
+          ),
+          child: Icon(
+            icon, 
+            size: iconSize, 
+            color: iconColor,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          label,
+          style: labelStyle ?? textTheme.labelMedium?.copyWith(
+            fontWeight: FontWeight.w600,
+            color: isDark ? Colors.white : AppColors.gray700,
+          ),
+        ),
+      ],
+    );
+  }
+} 

--- a/lib/constants/widgets/icon_container.dart
+++ b/lib/constants/widgets/icon_container.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+class IconContainer extends StatelessWidget {
+  final IconData icon;
+  final double size;
+  final double iconSize;
+  final Color? backgroundColor;
+  final Color? iconColor;
+  final double borderRadius;
+  final List<BoxShadow>? boxShadow;
+  final EdgeInsetsGeometry? padding;
+
+  const IconContainer({
+    super.key,
+    required this.icon,
+    this.size = 80,
+    this.iconSize = 44,
+    this.backgroundColor,
+    this.iconColor,
+    this.borderRadius = 20,
+    this.boxShadow,
+    this.padding,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Container(
+      width: size,
+      height: size,
+      padding: padding,
+      decoration: BoxDecoration(
+        color: backgroundColor ?? colorScheme.primaryContainer,
+        borderRadius: BorderRadius.circular(borderRadius),
+        boxShadow: boxShadow ?? [
+          BoxShadow(
+            color: theme.shadowColor.withValues(alpha: 0.10),
+            blurRadius: 16,
+            offset: const Offset(0, 6),
+          ),
+        ],
+      ),
+      child: Center(
+        child: Icon(
+          icon,
+          color: iconColor ?? colorScheme.primary,
+          size: iconSize,
+        ),
+      ),
+    );
+  }
+} 

--- a/lib/constants/widgets/unified_container.dart
+++ b/lib/constants/widgets/unified_container.dart
@@ -1,0 +1,251 @@
+import 'package:flutter/material.dart';
+
+class UnifiedContainer extends StatelessWidget {
+  final Widget child;
+  final EdgeInsetsGeometry? padding;
+  final double borderRadius;
+  final Color? backgroundColor;
+  final Color? borderColor;
+  final double borderWidth;
+  final List<BoxShadow>? boxShadow;
+  final double? width;
+  final double? height;
+  final bool isFormContainer;
+  final bool isCardContainer;
+  final bool isTransparent;
+
+  const UnifiedContainer({
+    super.key,
+    required this.child,
+    this.padding,
+    this.borderRadius = 16,
+    this.backgroundColor,
+    this.borderColor,
+    this.borderWidth = 1.0,
+    this.boxShadow,
+    this.width,
+    this.height,
+    this.isFormContainer = false,
+    this.isCardContainer = false,
+    this.isTransparent = false,
+  });
+
+  // Named constructors for specific use cases
+  const UnifiedContainer.form({
+    Key? key,
+    required Widget child,
+    EdgeInsetsGeometry? padding = const EdgeInsets.all(32),
+    double borderRadius = 16,
+    Color? backgroundColor,
+    List<BoxShadow>? boxShadow,
+    double? width,
+    double? height,
+  }) : this(
+          key: key,
+          child: child,
+          padding: padding,
+          borderRadius: borderRadius,
+          backgroundColor: backgroundColor,
+          boxShadow: boxShadow,
+          width: width,
+          height: height,
+          isFormContainer: true,
+        );
+
+  const UnifiedContainer.card({
+    Key? key,
+    required Widget child,
+    EdgeInsetsGeometry? padding,
+    double borderRadius = 16,
+    Color? backgroundColor,
+    Color? borderColor,
+    double borderWidth = 1.0,
+    List<BoxShadow>? boxShadow,
+    double? width,
+    double? height,
+  }) : this(
+          key: key,
+          child: child,
+          padding: padding,
+          borderRadius: borderRadius,
+          backgroundColor: backgroundColor,
+          borderColor: borderColor,
+          borderWidth: borderWidth,
+          boxShadow: boxShadow,
+          width: width,
+          height: height,
+          isCardContainer: true,
+        );
+
+  const UnifiedContainer.transparent({
+    Key? key,
+    required Widget child,
+    EdgeInsetsGeometry? padding,
+    double borderRadius = 16,
+    Color? borderColor,
+    double borderWidth = 1.0,
+    List<BoxShadow>? boxShadow,
+    double? width,
+    double? height,
+  }) : this(
+          key: key,
+          child: child,
+          padding: padding,
+          borderRadius: borderRadius,
+          borderColor: borderColor,
+          borderWidth: borderWidth,
+          boxShadow: boxShadow,
+          width: width,
+          height: height,
+          isTransparent: true,
+        );
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final isDark = theme.brightness == Brightness.dark;
+
+    // Determine background color based on type and theme
+    Color? finalBackgroundColor;
+    if (isTransparent) {
+      finalBackgroundColor = Colors.transparent;
+    } else if (backgroundColor != null) {
+      finalBackgroundColor = backgroundColor;
+    } else if (isFormContainer) {
+      finalBackgroundColor = theme.cardColor;
+    } else if (isCardContainer) {
+      finalBackgroundColor = theme.cardColor;
+    } else {
+      finalBackgroundColor = theme.cardColor;
+    }
+
+    // Determine border color based on type and theme
+    Color? finalBorderColor;
+    if (borderColor != null) {
+      finalBorderColor = borderColor;
+    } else if (isCardContainer) {
+      finalBorderColor = colorScheme.outlineVariant;
+    } else {
+      finalBorderColor = null; // No border for form containers by default
+    }
+
+    // Determine box shadow based on type and theme
+    List<BoxShadow>? finalBoxShadow;
+    if (boxShadow != null) {
+      finalBoxShadow = boxShadow;
+    } else if (isFormContainer) {
+      finalBoxShadow = [
+        BoxShadow(
+          color: colorScheme.shadow.withValues(
+            alpha: isDark ? 0.3 : 0.08,
+          ),
+          blurRadius: 20,
+          offset: const Offset(0, 6),
+        ),
+      ];
+    } else if (isCardContainer) {
+      finalBoxShadow = [
+        BoxShadow(
+          color: colorScheme.shadow.withValues(
+            alpha: isDark ? 0.18 : 0.06,
+          ),
+          blurRadius: 24,
+          offset: const Offset(0, 8),
+        ),
+      ];
+    }
+
+    return Container(
+      width: width,
+      height: height,
+      padding: padding,
+      decoration: BoxDecoration(
+        color: finalBackgroundColor,
+        borderRadius: BorderRadius.circular(borderRadius),
+        border: finalBorderColor != null
+            ? Border.all(color: finalBorderColor, width: borderWidth)
+            : null,
+        boxShadow: finalBoxShadow,
+      ),
+      child: child,
+    );
+  }
+}
+
+// Convenience classes for backward compatibility
+class FormContainer extends StatelessWidget {
+  final Widget child;
+  final EdgeInsetsGeometry? padding;
+  final double borderRadius;
+  final Color? backgroundColor;
+  final List<BoxShadow>? boxShadow;
+  final double? width;
+  final double? height;
+
+  const FormContainer({
+    super.key,
+    required this.child,
+    this.padding = const EdgeInsets.all(32),
+    this.borderRadius = 16,
+    this.backgroundColor,
+    this.boxShadow,
+    this.width,
+    this.height,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return UnifiedContainer.form(
+      key: key,
+      padding: padding,
+      borderRadius: borderRadius,
+      backgroundColor: backgroundColor,
+      boxShadow: boxShadow,
+      width: width,
+      height: height,
+      child: child,
+    );
+  }
+}
+
+class CardContainer extends StatelessWidget {
+  final Widget child;
+  final EdgeInsetsGeometry? padding;
+  final double borderRadius;
+  final Color? backgroundColor;
+  final Color? borderColor;
+  final double borderWidth;
+  final List<BoxShadow>? boxShadow;
+  final double? width;
+  final double? height;
+
+  const CardContainer({
+    super.key,
+    required this.child,
+    this.padding,
+    this.borderRadius = 16,
+    this.backgroundColor,
+    this.borderColor,
+    this.borderWidth = 1.0,
+    this.boxShadow,
+    this.width,
+    this.height,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return UnifiedContainer.card(
+      key: key,
+      padding: padding,
+      borderRadius: borderRadius,
+      backgroundColor: backgroundColor,
+      borderColor: borderColor,
+      borderWidth: borderWidth,
+      boxShadow: boxShadow,
+      width: width,
+      height: height,
+      child: child,
+    );
+  }
+} 

--- a/lib/presentation/screens/auth/auth_screen.dart
+++ b/lib/presentation/screens/auth/auth_screen.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import '../../../constants/widgets/background_wrapper.dart';
+import '../../../constants/widgets/icon_container.dart';
+import '../../../constants/widgets/feature_icon.dart';
 import '../../../constants/themes/app_colors.dart';
+
+import '../../widgets/auth/tab_bar.dart';
 import '../../widgets/auth/sign_in_form.dart';
 import '../../widgets/auth/sign_up_form.dart';
-import '../../widgets/auth/tab_bar.dart';
-import '../../widgets/auth/theme_toggle_button.dart';
 
 class AuthScreen extends StatefulWidget {
   const AuthScreen({super.key});
@@ -49,36 +51,15 @@ class _AuthScreenState extends State<AuthScreen>
                   child: Column(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
-                      const Row(
-                        mainAxisAlignment: MainAxisAlignment.end,
-                        children: [
-                          ThemeToggleButton(),
-                          SizedBox(width: 8),
-                        ],
-                      ),
                       // Top icon and texts
                       const SizedBox(height: 24),
-                      Container(
-                        width: 80,
-                        height: 80,
-                        decoration: BoxDecoration(
-                          color: AppColors.primary,
-                          borderRadius: BorderRadius.circular(20),
-                          boxShadow: [
-                            BoxShadow(
-                              color: theme.shadowColor.withValues(alpha: 0.10),
-                              blurRadius: 16,
-                              offset: const Offset(0, 6),
-                            ),
-                          ],
-                        ),
-                        child: Center(
-                          child: Icon(
-                            Icons.near_me_outlined,
-                            color: isDark ? Colors.black : Colors.white,
-                            size: 44,
-                          ),
-                        ),
+                      IconContainer(
+                        icon: Icons.near_me_outlined,
+                        size: 80,
+                        iconSize: 44,
+                        backgroundColor: AppColors.primary,
+                        iconColor: isDark ? Colors.black : Colors.white,
+                        borderRadius: 20,
                       ),
                       const SizedBox(height: 28),
                       Text(
@@ -126,19 +107,19 @@ class _AuthScreenState extends State<AuthScreen>
                         child: Row(
                           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                           children: [
-                            _FeatureIcon(
+                            FeatureIcon(
                               icon: Icons.place_outlined,
                               label: 'Discover Places',
                               iconColor: AppColors.discoverPlacesIcon,
                               bgColor: AppColors.discoverPlacesBg,
                             ),
-                            _FeatureIcon(
+                            FeatureIcon(
                               icon: Icons.directions,
                               label: 'Get Directions',
                               iconColor: AppColors.getDirectionsIcon,
                               bgColor: AppColors.getDirectionsBg,
                             ),
-                            _FeatureIcon(
+                            FeatureIcon(
                               icon: Icons.favorite_border,
                               label: 'Save Favorites',
                               iconColor: AppColors.saveFavoritesIcon,
@@ -156,61 +137,6 @@ class _AuthScreenState extends State<AuthScreen>
           ),
         ),
       ),
-    );
-  }
-}
-
-class _FeatureIcon extends StatelessWidget {
-  final IconData icon;
-  final String label;
-  final Color iconColor;
-  final Color bgColor;
-  
-  const _FeatureIcon({
-    required this.icon, 
-    required this.label, 
-    required this.iconColor, 
-    required this.bgColor,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final isDark = theme.brightness == Brightness.dark;
-    return Column(
-      children: [
-        Container(
-          width: 56,
-          height: 56,
-          decoration: BoxDecoration(
-            color: isDark ? iconColor.withValues(alpha: 0.2) : bgColor,
-            borderRadius: BorderRadius.circular(28),
-            boxShadow: [
-              BoxShadow(
-                color: isDark 
-                    ? Colors.black.withValues(alpha: 0.2) 
-                    : Colors.black.withValues(alpha: 0.08),
-                blurRadius: 8,
-                offset: const Offset(0, 3),
-              ),
-            ],
-          ),
-          child: Icon(
-            icon, 
-            size: 28, 
-            color: iconColor,
-          ),
-        ),
-        const SizedBox(height: 8),
-        Text(
-          label,
-          style: TextStyle(
-            fontWeight: FontWeight.w600,
-            fontSize: 14,
-            color: isDark ? Colors.white : AppColors.gray700,
-          ),
-        ),
-      ],
     );
   }
 }

--- a/lib/presentation/screens/auth/otp_error_message.dart
+++ b/lib/presentation/screens/auth/otp_error_message.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import '../../../constants/themes/app_colors.dart';
+import '../../../constants/themes/app_text_styles.dart';
+
+class OtpErrorMessage extends StatelessWidget {
+  final String message;
+  final bool showDemoHint;
+
+  const OtpErrorMessage({
+    super.key,
+    required this.message,
+    this.showDemoHint = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: isDark ? AppColors.gray800 : AppColors.gray100,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: AppColors.error.withValues(alpha: 0.3),
+          width: 1,
+        ),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            Icons.error_outline,
+            size: 16,
+            color: AppColors.error,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              message,
+              style: AppTextStyles.bodyMedium.copyWith(
+                color: AppColors.error,
+                fontSize: 13,
+              ),
+            ),
+          ),
+          if (showDemoHint) ...[
+            const SizedBox(width: 8),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              decoration: BoxDecoration(
+                color: AppColors.primary.withValues(alpha: 0.1),
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: Text(
+                '123456',
+                style: AppTextStyles.caption.copyWith(
+                  color: AppColors.primary,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+} 

--- a/lib/presentation/screens/auth/otp_screen.dart
+++ b/lib/presentation/screens/auth/otp_screen.dart
@@ -1,0 +1,160 @@
+import 'package:flutter/material.dart';
+import '../../../constants/widgets/background_wrapper.dart';
+import '../../widgets/auth/otp_header.dart';
+import '../../widgets/auth/otp_form_card.dart';
+import '../../widgets/auth/try_different_phone_link.dart';
+import '../../widgets/auth/secure_verification_card.dart';
+
+class OtpScreen extends StatefulWidget {
+  final String phoneNumber;
+  const OtpScreen({super.key, required this.phoneNumber});
+
+  @override
+  State<OtpScreen> createState() => _OtpScreenState();
+}
+
+class _OtpScreenState extends State<OtpScreen> {
+  final TextEditingController _otpController = TextEditingController();
+  int _timer = 30;
+  bool _isButtonEnabled = false;
+  bool _isVerifying = false;
+  bool _hasError = false;
+  String? _errorMessage;
+
+  @override
+  void initState() {
+    super.initState();
+    _startTimer();
+  }
+
+  @override
+  void dispose() {
+    _otpController.dispose();
+    super.dispose();
+  }
+
+  void _startTimer() {
+    Future.doWhile(() async {
+      if (_timer == 0) return false;
+      await Future.delayed(const Duration(seconds: 1));
+      if (mounted) setState(() => _timer--);
+      return _timer > 0;
+    });
+  }
+
+  void _verifyCode() async {
+    if (!_isButtonEnabled || _isVerifying) return;
+
+    setState(() {
+      _isVerifying = true;
+      _hasError = false;
+      _errorMessage = null;
+    });
+
+    // Simulate API call delay
+    await Future.delayed(const Duration(seconds: 2));
+
+    if (mounted) {
+      setState(() {
+        _isVerifying = false;
+      });
+
+      // Check if the code is correct (demo: 123456)
+      final enteredCode = _otpController.text;
+      if (enteredCode == "123456") {
+        // Navigate to home screen
+        Navigator.of(context).pushReplacementNamed('/home');
+      } else {
+        // Show error state
+        setState(() {
+          _hasError = true;
+          _errorMessage = "Invalid verification code. Try again or use 123456 for demo.";
+        });
+      }
+    }
+  }
+
+  void _handleOtpChanged(String value) {
+    setState(() {
+      _otpController.text = value;
+      _isButtonEnabled = value.length == 6;
+      // Clear error when user starts typing
+      if (_hasError) {
+        _hasError = false;
+        _errorMessage = null;
+      }
+    });
+  }
+
+  void _handleOtpCompleted(String value) {
+    setState(() {
+      _otpController.text = value;
+      _isButtonEnabled = value.length == 6;
+      // Clear error when user completes OTP
+      if (_hasError) {
+        _hasError = false;
+        _errorMessage = null;
+      }
+    });
+  }
+
+  void _handleResendCode() {
+    setState(() {
+      _timer = 30;
+    });
+    _startTimer();
+  }
+
+  void _handleTryDifferentPhone() {
+    // Navigate back to sign up form
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: AppBackground(
+        showThemeToggle: true,
+        showBackButton: true,
+        child: SafeArea(
+          child: Center(
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  // Header Section
+                  OtpHeader(phoneNumber: widget.phoneNumber),
+                  
+                  // Main Form Card
+                  OtpFormCard(
+                    otpController: _otpController,
+                    isButtonEnabled: _isButtonEnabled,
+                    isVerifying: _isVerifying,
+                    timer: _timer,
+                    hasError: _hasError,
+                    errorMessage: _errorMessage,
+                    onOtpChanged: _handleOtpChanged,
+                    onOtpCompleted: _handleOtpCompleted,
+                    onVerifyCode: _verifyCode,
+                    onResendCode: _handleResendCode,
+                  ),
+                  const SizedBox(height: 18),
+
+                  // Try Different Phone Link
+                  TryDifferentPhoneLink(
+                    onTryDifferentPhone: _handleTryDifferentPhone,
+                  ),
+                  const SizedBox(height: 24),
+
+                  // Secure Verification Card
+                  const SecureVerificationCard(),
+                  const SizedBox(height: 32),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/screens/home/home_screen.dart
+++ b/lib/presentation/screens/home/home_screen.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import '../../../constants/themes/app_colors.dart';
+import '../../../constants/themes/app_text_styles.dart';
+import '../../../constants/widgets/background_wrapper.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    return Scaffold(
+      body: AppBackground(
+        showThemeToggle: true,
+        showBackButton: false,
+        child: SafeArea(
+          child: Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                // Success Icon
+                Container(
+                  width: 100,
+                  height: 100,
+                  decoration: BoxDecoration(
+                    color: AppColors.success,
+                    borderRadius: BorderRadius.circular(50),
+                    boxShadow: [
+                      BoxShadow(
+                        color: AppColors.success.withValues(alpha: 0.3),
+                        blurRadius: 20,
+                        offset: const Offset(0, 8),
+                      ),
+                    ],
+                  ),
+                  child: const Icon(
+                    Icons.check,
+                    size: 50,
+                    color: Colors.white,
+                  ),
+                ),
+                const SizedBox(height: 32),
+
+                // Success Title
+                Text(
+                  'Verification Successful!',
+                  style: AppTextStyles.titleLargeThemed(context),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 16),
+
+                // Success Message
+                Text(
+                  'Your phone number has been verified successfully. Welcome to the app!',
+                  style: AppTextStyles.bodyLargeThemed(context),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 48),
+
+                // Continue Button
+                Container(
+                  width: 200,
+                  height: 48,
+                  decoration: BoxDecoration(
+                    color: AppColors.primary,
+                    borderRadius: BorderRadius.circular(12),
+                    boxShadow: [
+                      BoxShadow(
+                        color: AppColors.primary.withValues(alpha: 0.3),
+                        blurRadius: 8,
+                        offset: const Offset(0, 2),
+                      ),
+                    ],
+                  ),
+                  child: Material(
+                    color: Colors.transparent,
+                    child: InkWell(
+                      onTap: () {
+                        // Navigate to main app content
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(
+                            content: Text('Welcome to the main app!'),
+                            backgroundColor: AppColors.success,
+                          ),
+                        );
+                      },
+                      borderRadius: BorderRadius.circular(12),
+                      child: const Center(
+                        child: Text(
+                          'Continue',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 16,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+} 

--- a/lib/presentation/widgets/auth/custom_otp_field.dart
+++ b/lib/presentation/widgets/auth/custom_otp_field.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import '../../../constants/themes/app_colors.dart';
+import '../../../constants/themes/app_text_styles.dart';
+
+class CustomOtpField extends StatefulWidget {
+  final int length;
+  final Function(String) onChanged;
+  final Function(String)? onCompleted;
+  final bool autoFocus;
+  final TextStyle? textStyle;
+  final double fieldWidth;
+  final double fieldHeight;
+  final double spacing;
+  final Color? activeColor;
+  final Color? inactiveColor;
+  final Color? selectedColor;
+  final double borderRadius;
+  final double borderWidth;
+  final bool hasError;
+
+  const CustomOtpField({
+    super.key,
+    this.length = 6,
+    required this.onChanged,
+    this.onCompleted,
+    this.autoFocus = true,
+    this.textStyle,
+    this.fieldWidth = 45,
+    this.fieldHeight = 56,
+    this.spacing = 4,
+    this.activeColor,
+    this.inactiveColor,
+    this.selectedColor,
+    this.borderRadius = 12,
+    this.borderWidth = 1.5,
+    this.hasError = false,
+  });
+
+  @override
+  State<CustomOtpField> createState() => _CustomOtpFieldState();
+}
+
+class _CustomOtpFieldState extends State<CustomOtpField> {
+  late List<TextEditingController> _controllers;
+  late List<FocusNode> _focusNodes;
+  late List<String> _otpValues;
+
+  @override
+  void initState() {
+    super.initState();
+    _controllers = List.generate(
+      widget.length,
+      (index) => TextEditingController(),
+    );
+    _focusNodes = List.generate(
+      widget.length,
+      (index) => FocusNode(),
+    );
+    _otpValues = List.filled(widget.length, '');
+  }
+
+  @override
+  void dispose() {
+    for (var controller in _controllers) {
+      controller.dispose();
+    }
+    for (var focusNode in _focusNodes) {
+      focusNode.dispose();
+    }
+    super.dispose();
+  }
+
+  void _onOtpChanged(String value, int index) {
+    if (value.length > 1) {
+      value = value[value.length - 1];
+    }
+
+    setState(() {
+      _otpValues[index] = value;
+    });
+
+    // Move to next field
+    if (value.isNotEmpty && index < widget.length - 1) {
+      _focusNodes[index + 1].requestFocus();
+    }
+
+    // Move to previous field on backspace
+    if (value.isEmpty && index > 0) {
+      _focusNodes[index - 1].requestFocus();
+    }
+
+    final otp = _otpValues.join();
+    widget.onChanged(otp);
+
+    if (otp.length == widget.length) {
+      widget.onCompleted?.call(otp);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final textTheme = theme.textTheme;
+
+    // Colors based on design
+    final activeColor = widget.activeColor ?? AppColors.primary;
+    final inactiveColor = widget.hasError 
+        ? AppColors.error 
+        : (widget.inactiveColor ?? (isDark ? Colors.white24 : AppColors.gray300));
+    final selectedColor = widget.selectedColor ?? AppColors.primary;
+    final cursorColor = isDark ? Colors.white : AppColors.gray900;
+    final textColor = isDark ? Colors.white : AppColors.gray900;
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        // Calculate available width and adjust field size accordingly
+        final availableWidth = constraints.maxWidth;
+        final totalSpacing = (widget.length - 1) * widget.spacing;
+        final fieldWidth = (availableWidth - totalSpacing - 8) / widget.length; // Added safety margin
+        
+                 return Row(
+           mainAxisAlignment: MainAxisAlignment.spaceBetween,
+           children: List.generate(
+             widget.length,
+             (index) => SizedBox(
+               width: fieldWidth,
+               height: widget.fieldHeight,
+               child: TextField(
+                controller: _controllers[index],
+                focusNode: _focusNodes[index],
+                textAlign: TextAlign.center,
+                keyboardType: TextInputType.number,
+                cursorColor: cursorColor,
+                cursorWidth: 2,
+                cursorHeight: 24,
+                inputFormatters: [
+                  FilteringTextInputFormatter.digitsOnly,
+                  LengthLimitingTextInputFormatter(1),
+                ],
+                style: widget.textStyle ?? AppTextStyles.otpField.copyWith(
+                  color: textColor,
+                ),
+                decoration: InputDecoration(
+                  filled: true,
+                  fillColor: isDark ? AppColors.gray700 : AppColors.gray100,
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(widget.borderRadius),
+                    borderSide: BorderSide(
+                      color: inactiveColor,
+                      width: widget.borderWidth,
+                    ),
+                  ),
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(widget.borderRadius),
+                    borderSide: BorderSide(
+                      color: inactiveColor,
+                      width: widget.borderWidth,
+                    ),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(widget.borderRadius),
+                    borderSide: BorderSide(
+                      color: _otpValues[index].isNotEmpty ? selectedColor : activeColor,
+                      width: widget.borderWidth,
+                    ),
+                  ),
+                  contentPadding: EdgeInsets.zero,
+                ),
+                onChanged: (value) => _onOtpChanged(value, index),
+                onTap: () {
+                  setState(() {});
+                },
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+} 

--- a/lib/presentation/widgets/auth/otp_error_message.dart
+++ b/lib/presentation/widgets/auth/otp_error_message.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import '../../../constants/themes/app_colors.dart';
+import '../../../constants/themes/app_text_styles.dart';
+
+class OtpErrorMessage extends StatelessWidget {
+  final String message;
+  final bool showDemoHint;
+
+  const OtpErrorMessage({
+    super.key,
+    required this.message,
+    this.showDemoHint = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: isDark ? AppColors.gray800 : AppColors.gray100,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: AppColors.error.withValues(alpha: 0.3),
+          width: 1,
+        ),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            Icons.error_outline,
+            size: 16,
+            color: AppColors.error,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              message,
+              style: AppTextStyles.bodyMedium.copyWith(
+                color: AppColors.error,
+                fontSize: 13,
+              ),
+            ),
+          ),
+          if (showDemoHint) ...[
+            const SizedBox(width: 8),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              decoration: BoxDecoration(
+                color: AppColors.primary.withValues(alpha: 0.1),
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: Text(
+                '123456',
+                style: AppTextStyles.caption.copyWith(
+                  color: AppColors.primary,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+} 

--- a/lib/presentation/widgets/auth/otp_form_card.dart
+++ b/lib/presentation/widgets/auth/otp_form_card.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import '../../../constants/themes/app_colors.dart';
+import '../../../constants/themes/app_text_styles.dart';
+import '../../../constants/widgets/unified_container.dart';
+import 'custom_otp_field.dart';
+import 'verify_code_button.dart';
+import 'resend_code_section.dart';
+import 'otp_error_message.dart';
+
+class OtpFormCard extends StatelessWidget {
+  final TextEditingController otpController;
+  final bool isButtonEnabled;
+  final bool isVerifying;
+  final int timer;
+  final bool hasError;
+  final String? errorMessage;
+  final Function(String) onOtpChanged;
+  final Function(String)? onOtpCompleted;
+  final VoidCallback onVerifyCode;
+  final VoidCallback onResendCode;
+
+  const OtpFormCard({
+    super.key,
+    required this.otpController,
+    required this.isButtonEnabled,
+    required this.isVerifying,
+    required this.timer,
+    this.hasError = false,
+    this.errorMessage,
+    required this.onOtpChanged,
+    required this.onOtpCompleted,
+    required this.onVerifyCode,
+    required this.onResendCode,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8.0),
+      child: UnifiedContainer(
+        width: 380,
+        padding: const EdgeInsets.all(32),
+        borderRadius: 20,
+        borderColor: isDark ? AppColors.gray600 : AppColors.gray300,
+        borderWidth: 0.3,
+        child: Column(
+          children: [
+            // Card Title
+            Text(
+              'Enter Verification Code',
+              style: AppTextStyles.titleMediumThemed(context),
+            ),
+            const SizedBox(height: 8),
+
+            // Card Subtitle
+            Text(
+              'Enter the 6-digit code we sent to your phone',
+              style: AppTextStyles.bodyMediumThemed(context),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 28),
+
+            // OTP Fields
+            CustomOtpField(
+              fieldHeight: 56,
+              spacing: 4,
+              borderRadius: 12,
+              borderWidth: 1.5,
+              hasError: hasError,
+              onChanged: onOtpChanged,
+              onCompleted: onOtpCompleted,
+            ),
+            if (hasError && errorMessage != null) ...[
+              const SizedBox(height: 12),
+              OtpErrorMessage(message: errorMessage!),
+            ],
+            const SizedBox(height: 16),
+
+            // Demo Code Button
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              decoration: BoxDecoration(
+                color: AppColors.primaryHover.withValues(alpha: 0.30),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Text(
+                'Demo: Use code 123456',
+                style: AppTextStyles.labelLarge.copyWith(
+                  color: Colors.blueAccent,
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+
+            // Resend Code Section
+            ResendCodeSection(
+              timer: timer,
+              onResendCode: onResendCode,
+            ),
+            const SizedBox(height: 24),
+
+            // Verify Code Button
+            VerifyCodeButton(
+              isEnabled: isButtonEnabled,
+              isVerifying: isVerifying,
+              onVerifyCode: onVerifyCode,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+} 

--- a/lib/presentation/widgets/auth/otp_header.dart
+++ b/lib/presentation/widgets/auth/otp_header.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import '../../../constants/themes/app_colors.dart';
+import '../../../constants/themes/app_text_styles.dart';
+
+class OtpHeader extends StatelessWidget {
+  final String phoneNumber;
+
+  const OtpHeader({
+    super.key,
+    required this.phoneNumber,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final phone = _maskPhone(phoneNumber);
+
+    return Column(
+      children: [
+        // Shield Icon
+        Container(
+          width: 85,
+          height: 85,
+          decoration: BoxDecoration(
+            color: AppColors.primary,
+            borderRadius: BorderRadius.circular(20),
+            boxShadow: [
+              BoxShadow(
+                color: AppColors.primary.withValues(alpha: 0.3),
+                blurRadius: 20,
+                offset: const Offset(0, 8),
+              ),
+            ],
+          ),
+          child: Icon(
+            Icons.shield_outlined,
+            size: 40,
+            color: isDark ? Colors.black : Colors.white,
+          ),
+        ),
+        const SizedBox(height: 24),
+
+        // Title
+        Text(
+          'Verify Your Phone',
+          style: AppTextStyles.titleLargeThemed(context),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 8),
+
+        // Subtitle
+        Text(
+          'We sent a 6-digit code to',
+          style: AppTextStyles.bodyLargeThemed(context),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 2),
+        Text(
+          phone,
+          style: AppTextStyles.bodyLargeThemed(context).copyWith(
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        const SizedBox(height: 32),
+      ],
+    );
+  }
+
+  String _maskPhone(String phone) {
+    if (phone.length < 4) return phone;
+    return phone.replaceRange(3, phone.length - 2, '*' * (phone.length - 5));
+  }
+} 

--- a/lib/presentation/widgets/auth/password_form_field.dart
+++ b/lib/presentation/widgets/auth/password_form_field.dart
@@ -68,7 +68,7 @@ class _PasswordFormFieldState extends State<PasswordFormField> {
             ),
             focusedBorder: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
-              borderSide: BorderSide(
+              borderSide: const BorderSide(
                 color: AppColors.primary,
                 width: 2,
               ),

--- a/lib/presentation/widgets/auth/resend_code_section.dart
+++ b/lib/presentation/widgets/auth/resend_code_section.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import '../../../constants/themes/app_colors.dart';
+import '../../../constants/themes/app_text_styles.dart';
+
+class ResendCodeSection extends StatelessWidget {
+  final int timer;
+  final VoidCallback onResendCode;
+
+  const ResendCodeSection({
+    super.key,
+    required this.timer,
+    required this.onResendCode,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return timer > 0
+        ? Text(
+            'Resend code in 0:${timer.toString().padLeft(2, '0')}',
+            style: AppTextStyles.bodyMediumThemed(context),
+          )
+        : GestureDetector(
+            onTap: onResendCode,
+            child: Container(
+              padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(
+                    Icons.refresh_rounded,
+                    size: 16,
+                    color: AppColors.primary,
+                  ),
+                  const SizedBox(width: 6),
+                  Text(
+                    'Resend Code',
+                    style: AppTextStyles.buttonSecondaryThemed(context),
+                  ),
+                ],
+              ),
+            ),
+          );
+  }
+} 

--- a/lib/presentation/widgets/auth/secure_verification_card.dart
+++ b/lib/presentation/widgets/auth/secure_verification_card.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import '../../../constants/themes/app_colors.dart';
+import '../../../constants/themes/app_text_styles.dart';
+import '../../../constants/widgets/unified_container.dart';
+
+class SecureVerificationCard extends StatelessWidget {
+  const SecureVerificationCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8.0),
+      child: UnifiedContainer(
+        width: 380,
+        padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 18),
+        borderRadius: 12,
+        borderColor: AppColors.gray500,
+        borderWidth: 0.5,
+        child: Row(
+          children: [
+            Container(
+              width: 32,
+              height: 32,
+              decoration: BoxDecoration(
+                color: AppColors.success.withValues(alpha: 0.15),
+                borderRadius: BorderRadius.circular(320),
+              ),
+              child: const Icon(
+                Icons.shield_outlined,
+                color: AppColors.success,
+                size: 20,
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Secure Verification',
+                    style: AppTextStyles.labelLarge.copyWith(
+                      fontWeight: FontWeight.w700,
+                      color: isDark ? Colors.white : AppColors.gray900,
+                      fontSize: 15,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    'Your phone number helps keep your account safe',
+                    style: AppTextStyles.caption.copyWith(
+                      color: isDark
+                          ? Colors.white.withValues(alpha: 0.7)
+                          : AppColors.gray600,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+} 

--- a/lib/presentation/widgets/auth/sign_in_form.dart
+++ b/lib/presentation/widgets/auth/sign_in_form.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import '../../../constants/themes/app_colors.dart';
+import '../../../constants/themes/app_text_styles.dart';
+import '../../../constants/widgets/unified_container.dart';
+import '../../../constants/widgets/app_button.dart';
 import 'custom_text_form_field.dart';
 import 'password_form_field.dart';
 
@@ -12,41 +15,23 @@ class SignInForm extends StatelessWidget {
     final isDark = theme.brightness == Brightness.dark;
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8.0),
-      child: Container(
-        padding: const EdgeInsets.all(15),
-        decoration: BoxDecoration(
-          color: isDark ? AppColors.gray700 : Colors.white,
-          borderRadius: BorderRadius.circular(16),
-          boxShadow: [
-            BoxShadow(
-              color: isDark
-                  ? Colors.black.withValues(alpha: 0.3)
-                  : Colors.black.withValues(alpha: 0.08),
-              blurRadius: 20,
-              offset: const Offset(0, 6),
-            ),
-          ],
-        ),
+      child: UnifiedContainer(
+        padding: const EdgeInsets.all(32),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             Text(
               'Welcome Back',
-              style: TextStyle(
+              style: AppTextStyles.titleLarge.copyWith(
                 fontSize: 28,
-                fontWeight: FontWeight.w700,
                 color: isDark ? Colors.white : AppColors.gray900,
-                letterSpacing: -0.5,
               ),
             ),
             const SizedBox(height: 8),
             Text(
               'Sign in to access your saved places and history',
-              style: TextStyle(
-                fontSize: 16,
-                fontWeight: FontWeight.w400,
-                color: isDark ? Colors.white70 : AppColors.gray600,
-                height: 1.4,
+              style: AppTextStyles.bodyLarge.copyWith(
+                color: isDark ? Colors.white.withValues(alpha: 0.8) : AppColors.gray600,
               ),
               textAlign: TextAlign.center,
             ),
@@ -63,56 +48,14 @@ class SignInForm extends StatelessWidget {
                   const SizedBox(height: 20),
                   const PasswordFormField(label: 'Password'),
                   const SizedBox(height: 32),
-                  SizedBox(
-                    width: double.infinity,
-                    child: ElevatedButton(
-                      onPressed: () {},
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: AppColors.primary,
-                        foregroundColor: Colors.white,
-                        minimumSize: const Size.fromHeight(52),
-                        shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(12)),
-                        elevation: 0,
-                      ),
-                      child: Text(
-                        "Sign In",
-                        style: TextStyle(
-                          fontSize: 16,
-                          fontWeight: FontWeight.w600,
-                          color: isDark ? Colors.black : Colors.white,
-                          letterSpacing: 0.2,
-                        ),
-                      ),
-                    ),
+                  PrimaryButton(
+                    text: "Sign In",
+                    onPressed: () {},
                   ),
                   const SizedBox(height: 12),
-                  SizedBox(
-                    width: double.infinity,
-                    child: OutlinedButton(
-                      onPressed: () {},
-                      style: OutlinedButton.styleFrom(
-                        backgroundColor:
-                            isDark ? AppColors.gray700 : Colors.white,
-                        foregroundColor: isDark ? Colors.white : AppColors.gray900,
-                        side: BorderSide(
-                          color: isDark ? Colors.white24 : AppColors.gray300,
-                          width: 1.5,
-                        ),
-                        minimumSize: const Size.fromHeight(52),
-                        shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(12)),
-                        elevation: 0,
-                      ),
-                      child: const Text(
-                        "Continue as Guest",
-                        style: TextStyle(
-                          fontWeight: FontWeight.w600, 
-                          fontSize: 16,
-                          letterSpacing: 0.2,
-                        ),
-                      ),
-                    ),
+                  SecondaryButton(
+                    text: "Continue as Guest",
+                    onPressed: () {},
                   ),
                 ],
               ),

--- a/lib/presentation/widgets/auth/sign_up_form.dart
+++ b/lib/presentation/widgets/auth/sign_up_form.dart
@@ -1,144 +1,110 @@
 import 'package:flutter/material.dart';
 import '../../../constants/themes/app_colors.dart';
+import '../../../constants/themes/app_text_styles.dart';
+import '../../../constants/widgets/unified_container.dart';
+import '../../../constants/widgets/app_button.dart';
 import 'custom_text_form_field.dart';
 import 'password_form_field.dart';
 import 'phone_form_field.dart';
+import '../../screens/auth/otp_screen.dart';
 
-class SignUpForm extends StatelessWidget {
+class SignUpForm extends StatefulWidget {
   const SignUpForm({super.key});
+
+  @override
+  State<SignUpForm> createState() => _SignUpFormState();
+}
+
+class _SignUpFormState extends State<SignUpForm> {
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  final TextEditingController _phoneController = TextEditingController();
+
+  void _onCreateAccount() {
+    if (_formKey.currentState!.validate()) {
+      Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (context) => OtpScreen(phoneNumber: _phoneController.text),
+        ),
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _phoneController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final isDark = theme.brightness == Brightness.dark;
-    TextEditingController _phoneController = TextEditingController();
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8.0),
-      child: Container(
-        padding: const EdgeInsets.all(15),
-        decoration: BoxDecoration(
-          color: isDark ? AppColors.gray700 : Colors.white,
-          borderRadius: BorderRadius.circular(16),
-          boxShadow: [
-            BoxShadow(
-              color: isDark
-                  ? Colors.black.withValues(alpha: 0.3)
-                  : Colors.black.withValues(alpha: 0.08),
-              blurRadius: 20,
-              offset: const Offset(0, 6),
-            ),
-          ],
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            Text(
+      child: UnifiedContainer(
+        padding: const EdgeInsets.all(32),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+                          Text(
               'Create Account',
-              style: TextStyle(
+              style: AppTextStyles.titleLarge.copyWith(
                 fontSize: 28,
-                fontWeight: FontWeight.w700,
                 color: isDark ? Colors.white : AppColors.gray900,
-                letterSpacing: -0.5,
               ),
             ),
-            const SizedBox(height: 8),
-            Text(
-              'Join to save your favorite places and travel history',
-              style: TextStyle(
-                fontSize: 16,
-                fontWeight: FontWeight.w400,
-                color: isDark ? Colors.white70 : AppColors.gray600,
-                height: 1.4,
+              const SizedBox(height: 8),
+              Text(
+                'Join to save your favorite places and travel history',
+                style: AppTextStyles.bodyLarge.copyWith(
+                  color: isDark ? Colors.white.withValues(alpha: 0.8) : AppColors.gray600,
+                ),
+                textAlign: TextAlign.center,
               ),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 32),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8),
-              child: Column(
-                children: [
-                  const CustomTextFormField(
-                    label: 'Full Name',
-                    hint: 'Enter your full name',
-                    prefixIcon: Icons.person_outline,
-                  ),
-                  const SizedBox(height: 20),
-                  const CustomTextFormField(
-                    label: 'Email Address',
-                    hint: 'Enter your email',
-                    prefixIcon: Icons.email_outlined,
-                  ),
-                  const SizedBox(height: 20),
-                  PhoneFormField(
-                    controller: _phoneController,
-                  ),
-                  const SizedBox(height: 20),
-                  const PasswordFormField(
-                    label: 'Password',
-                    hintText: 'Create a password',
-                  ),
-                  const SizedBox(height: 20),
-                  const PasswordFormField(
-                    label: 'Confirm Password',
-                    hintText: 'Confirm your password',
-                  ),
-                  const SizedBox(height: 32),
-                  SizedBox(
-                    width: double.infinity,
-                    child: ElevatedButton(
-                      onPressed: () {},
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: AppColors.primary,
-                        foregroundColor: Colors.white,
-                        minimumSize: const Size.fromHeight(52),
-                        shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(12)),
-                        elevation: 0,
-                      ),
-                      child: Text(
-                        "Create Account",
-                        style: TextStyle(
-                          fontSize: 16,
-                          fontWeight: FontWeight.w600,
-                          color: isDark ? Colors.black : Colors.white,
-                          letterSpacing: 0.2,
-                        ),
-                      ),
+              const SizedBox(height: 32),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8),
+                child: Column(
+                  children: [
+                    const CustomTextFormField(
+                      label: 'Full Name',
+                      hint: 'Enter your full name',
+                      prefixIcon: Icons.person_outline,
                     ),
-                  ),
-                  const SizedBox(height: 12),
-                  SizedBox(
-                    width: double.infinity,
-                    child: OutlinedButton(
-                      onPressed: () {},
-                      style: OutlinedButton.styleFrom(
-                        backgroundColor:
-                            isDark ? AppColors.gray700 : Colors.white,
-                        foregroundColor:
-                            isDark ? Colors.white : AppColors.gray900,
-                        side: BorderSide(
-                          color: isDark ? Colors.white24 : AppColors.gray300,
-                          width: 1.5,
-                        ),
-                        minimumSize: const Size.fromHeight(52),
-                        shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(12)),
-                        elevation: 0,
-                      ),
-                      child: const Text(
-                        "Continue as Guest",
-                        style: TextStyle(
-                          fontWeight: FontWeight.w600,
-                          fontSize: 16,
-                          letterSpacing: 0.2,
-                        ),
-                      ),
+                    const SizedBox(height: 20),
+                    const CustomTextFormField(
+                      label: 'Email Address',
+                      hint: 'Enter your email',
+                      prefixIcon: Icons.email_outlined,
                     ),
-                  ),
-                ],
+                    const SizedBox(height: 20),
+                    PhoneFormField(
+                      controller: _phoneController,
+                    ),
+                    const SizedBox(height: 20),
+                    const PasswordFormField(label: 'Password'),
+                    const SizedBox(height: 20),
+                    const PasswordFormField(
+                      label: 'Confirm Password',
+                      hintText: 'Confirm your password',
+                    ),
+                    const SizedBox(height: 32),
+                    PrimaryButton(
+                      text: "Create Account",
+                      onPressed: _onCreateAccount,
+                    ),
+                    const SizedBox(height: 12),
+                    SecondaryButton(
+                      text: "Continue as Guest",
+                      onPressed: () {},
+                    ),
+                  ],
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/presentation/widgets/auth/tab_bar.dart
+++ b/lib/presentation/widgets/auth/tab_bar.dart
@@ -48,7 +48,7 @@ class AuthTabBar extends StatelessWidget {
             ),
             indicatorSize: TabBarIndicatorSize.tab,
             dividerColor: Colors.transparent,
-            overlayColor: MaterialStateProperty.all(Colors.transparent),
+            overlayColor: WidgetStateProperty.all(Colors.transparent),
             labelStyle: const TextStyle(
               fontSize: 16, 
               fontWeight: FontWeight.w600,

--- a/lib/presentation/widgets/auth/theme_toggle_button.dart
+++ b/lib/presentation/widgets/auth/theme_toggle_button.dart
@@ -13,7 +13,7 @@ class ThemeToggleButton extends StatelessWidget {
     final themeModel = Provider.of<ThemeModel>(context);
 
     return Padding(
-      padding: const EdgeInsets.only(top: 16, right: 16),
+      padding: const EdgeInsets.only(top: 12, right: 6),
       child: Align(
         alignment: Alignment.topRight,
         child: IconButton(

--- a/lib/presentation/widgets/auth/try_different_phone_link.dart
+++ b/lib/presentation/widgets/auth/try_different_phone_link.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import '../../../constants/themes/app_text_styles.dart';
+
+class TryDifferentPhoneLink extends StatelessWidget {
+  final VoidCallback onTryDifferentPhone;
+
+  const TryDifferentPhoneLink({
+    super.key,
+    required this.onTryDifferentPhone,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Text.rich(
+      TextSpan(
+        text: "Didn't receive the code? Check your messages or ",
+        style: AppTextStyles.bodyMediumThemed(context),
+        children: [
+          WidgetSpan(
+            child: GestureDetector(
+              onTap: onTryDifferentPhone,
+              child: Text(
+                'try a different phone number',
+                style: AppTextStyles.linkThemed(context),
+              ),
+            ),
+          ),
+        ],
+      ),
+      textAlign: TextAlign.center,
+    );
+  }
+} 

--- a/lib/presentation/widgets/auth/verify_code_button.dart
+++ b/lib/presentation/widgets/auth/verify_code_button.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import '../../../constants/themes/app_colors.dart';
+import '../../../constants/themes/app_text_styles.dart';
+
+class VerifyCodeButton extends StatelessWidget {
+  final bool isEnabled;
+  final bool isVerifying;
+  final VoidCallback onVerifyCode;
+
+  const VerifyCodeButton({
+    super.key,
+    required this.isEnabled,
+    required this.isVerifying,
+    required this.onVerifyCode,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    return GestureDetector(
+      onTap: isEnabled ? onVerifyCode : null,
+      child: Container(
+        width: double.infinity,
+        height: 48,
+        decoration: BoxDecoration(
+          color: AppColors.primary.withValues(alpha: 0.7),
+          borderRadius: BorderRadius.circular(12),
+          boxShadow: isEnabled
+              ? [
+                  BoxShadow(
+                    color: AppColors.primary.withValues(alpha: 0.3),
+                    blurRadius: 8,
+                    offset: const Offset(0, 2),
+                  ),
+                ]
+              : null,
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            _buildIcon(isDark),
+            const SizedBox(width: 8),
+            _buildText(isDark),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildIcon(bool isDark) {
+    if (isVerifying) {
+      return SizedBox(
+        width: 20,
+        height: 20,
+        child: CircularProgressIndicator(
+          strokeWidth: 2,
+          valueColor: AlwaysStoppedAnimation<Color>(
+            isDark ? Colors.black : Colors.white,
+          ),
+        ),
+      );
+    }
+
+    return Icon(
+      Icons.check,
+      size: 20,
+      color: isEnabled
+          ? (isDark ? Colors.black : Colors.white)
+          : (isDark ? AppColors.gray800 : AppColors.gray100),
+    );
+  }
+
+  Widget _buildText(bool isDark) {
+    return Text(
+      isVerifying ? "Verifying..." : "Verify Code",
+      style: AppTextStyles.buttonLarge.copyWith(
+        color: isEnabled
+            ? (isDark ? Colors.black : Colors.white)
+            : (isDark ? AppColors.gray800 : AppColors.gray100),
+      ),
+    );
+  }
+} 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -272,6 +272,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  pin_code_fields:
+    dependency: "direct main"
+    description:
+      name: pin_code_fields
+      sha256: "4c0db7fbc889e622e7c71ea54b9ee624bb70c7365b532abea0271b17ea75b729"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.1"
   platform:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,13 +29,12 @@ environment:
 # versions available, run `flutter pub outdated`.
 dependencies:
   cupertino_icons: ^1.0.8
-  # firebase dependencies
   firebase_auth: ^5.7.0
   firebase_core: ^3.15.2
   flutter:
     sdk: flutter
-  # state management
   flutter_bloc: ^9.1.1
+  pin_code_fields: ^8.0.1
   provider: ^6.1.2
   shared_preferences: ^2.3.2
 


### PR DESCRIPTION
- Create UI for OTP verification flow with custom input fields

  * OtpHeader - displays phone number and verification info
  * OtpFormCard - main form container with OTP fields
  * CustomOtpField - responsive 6-digit input with error states
  * VerifyCodeButton - dual-state button (normal/verifying)
  * ResendCodeSection - timer and resend functionality
  * SecureVerificationCard - security information display
  * TryDifferentPhoneLink - navigation back to signup
  * OtpErrorMessage - styled error display with demo hint
- Follow clean code principles with extracted sub-widgets
<img width="295" height="609" alt="Screenshot 2025-07-30 205120" src="https://github.com/user-attachments/assets/0acaec66-2b16-4233-9ed7-8a9a6d3c1363" />
<img width="308" height="668" alt="Screenshot 2025-07-30 205033" src="https://github.com/user-attachments/assets/9e2ba95c-3587-4924-9d09-700d15534480" />
